### PR TITLE
Remove redundant test

### DIFF
--- a/spec/ruby_brain_spec.rb
+++ b/spec/ruby_brain_spec.rb
@@ -4,8 +4,4 @@ describe RubyBrain do
   it 'has a version number' do
     expect(RubyBrain::VERSION).not_to be nil
   end
-
-  it 'does something useful' do
-    expect(false).to eq(true)
-  end
 end


### PR DESCRIPTION
When I ran `$ rake spec`, a failure below occurred.
Since the test is meaningless and unnecessary, I just removed it.

```
RubyBrain
  has a version number
  does something useful (FAILED - 1)

Failures:

  1) RubyBrain does something useful
     Failure/Error: expect(false).to eq(true)

       expected: true
            got: false

       (compared using ==)
     # ./spec/ruby_brain_spec.rb:9:in `block (2 levels) in <top (required)>'

Finished in 0.10396 seconds (files took 1.8 seconds to load)
2 examples, 1 failure

Failed examples:

rspec ./spec/ruby_brain_spec.rb:8 # RubyBrain does something useful

```
